### PR TITLE
fix NanoDet.h missing-declarations-warnings

### DIFF
--- a/demo_android_ncnn/app/src/main/cpp/NanoDet.h
+++ b/demo_android_ncnn/app/src/main/cpp/NanoDet.h
@@ -14,7 +14,7 @@ typedef struct HeadInfo
     std::string cls_layer;
     std::string dis_layer;
     int stride;
-};
+} HeadInfo;
 
 
 class NanoDet{


### PR DESCRIPTION
发现android ncnn demo中 有一个编译warning，修复了一下