### PR TITLE
fix learning rate problem

### DIFF
--- a/nanodet/trainer/trainer.py
+++ b/nanodet/trainer/trainer.py
@@ -126,6 +126,11 @@ class Trainer:
 
         self._init_scheduler()
         self.lr_scheduler.last_epoch = start_epoch - 1
+        
+        # resume learning rate of last epoch
+        if start_epoch > 1:
+            for param_group, lr in zip(self.optimizer.param_groups, self.lr_scheduler.get_lr()):
+                param_group['lr'] = lr
 
         for epoch in range(start_epoch, self.cfg.schedule.total_epochs + 1):
             results, train_loss_dict = self.run_epoch(epoch, train_loader, mode='train')


### PR DESCRIPTION
修复了resume train时， 学习率不下降的问题。
大佬，照着你在issue中提到的调节 学习率的方法基本复现了模型的精度。但在调参的过程中，发现里面有一个小小的bug,修复了一下。
问题描述：
假设，学习率的milestone为[100,140,150], 当模型在120epoch时，coco val的结果好于130 epoch的，把120 epoch的model_best.pth作为resume的model 权重，再调整学习率，设置milestone为[100,120,130]使得学习率在121 epoch时下降为**0.0014**， 但实际情况 121 epoch学习率仍然为 120 epoch的学习率[**0.014**], 学习率没有下降，好像是model_best.pth保存的优化器参数中的学习率为**0.014**导致的. 
我参照你的代码，添加了更新优化器中的学习率的逻辑，应该可以了。