### PR TITLE
Fix a bug in mnn demo while using GPU device

### DIFF
--- a/demo_mnn/nanodet_mnn.cpp
+++ b/demo_mnn/nanodet_mnn.cpp
@@ -71,7 +71,7 @@ int NanoDet::detect(cv::Mat &raw_image, std::vector<BoxInfo> &result_list)
         MNN::Tensor tensor_boxes_host(tensor_boxes, tensor_boxes->getDimensionType());
         tensor_boxes->copyToHostTensor(&tensor_boxes_host);
 
-        decode_infer(tensor_scores, tensor_boxes, head_info.stride, score_threshold, results);
+        decode_infer(&tensor_scores_host, &tensor_boxes_host, head_info.stride, score_threshold, results);
     }
 
     auto end = chrono::steady_clock::now();


### PR DESCRIPTION
使用MNN的GPU backend的时候，由于这边变量似乎传反了，NanoDet::decode_infer中的cls_pred->host会是空指针，CPU demo下没有这个问题因为不存在GPU和CPU之间的内存拷贝。