### PR TITLE
[Refactor]: Refactor data pipeline and support multi-scale training.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,28 +17,13 @@
 ****
 ## NEWS!!!
 
+* [2021.08.28] Refactor data processing pipeline and support multi-scale training (#311).
+
 * [2021.05.30] Release ncnn int8 models, and new pre-trained models with ShuffleNetV2-1.5x backbone. Much higher mAP but still realtime(**26.8mAP 21.53ms**).
 
 * [2021.03.12] Apply the **Transformer** encoder to NanoDet! Introducing **NanoDet-t**, which replaces the PAN in NanoDet-m with a **TAN(Transformer Attention Net)**,  gets 21.7 mAP(+1.1) on COCO val 2017. Check [nanodet-t.yml](config/Transformer/nanodet-t.yml) for more details.
 
-* [2021.03.03] Update **Nanodet-m-416** COCO pretrained model. **COCO mAP(0.5:0.95)=23.5**. Download in [Model Zoo](#model-zoo).
-
-* [2021.02.03] Support [EfficientNet-Lite](https://github.com/RangiLyu/EfficientNet-Lite) and [Rep-VGG](https://github.com/DingXiaoH/RepVGG) backbone. Please check the [config folder](config/). Download models in [Model Zoo](#model-zoo)
-
-* [2021.01.10] **NanoDet-g** with lower memory access cost, which designed for edge NPU or GPU, is now available!
-  Check [config/nanodet-g.yml](config/nanodet-g.yml) and download in [Model Zoo](#model-zoo).
-
-<details>
-<summary>More...</summary>
-
-* [2020.12.19] [MNN python and cpp demos](demo_mnn/) are available.
-
-* [2020.12.05] Support voc .xml format dataset! Refer to [config/nanodet_custom_xml_dataset.yml](config/nanodet_custom_xml_dataset.yml).
-
-* [2020.12.01] Great thanks to nihui, now you can try NanoDet running in web browser! 👉 https://nihui.github.io/ncnn-webassembly-nanodet/
-
-</details>
-
+Find more update notes in [Update notes](docs/update.md).
 ****
 ## Benchmarks
 

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -5,6 +5,7 @@ import time
 import cv2
 import torch
 
+from nanodet.data.collate import naive_collate
 from nanodet.data.transform import Pipeline
 from nanodet.model.arch import build_model
 from nanodet.util import Logger, cfg, load_config, load_model_weight
@@ -67,6 +68,8 @@ class Predictor(object):
             .unsqueeze(0)
             .to(self.device)
         )
+        meta = naive_collate([meta])
+        meta["img"] = meta["img"][0]
         with torch.no_grad():
             results = self.model.inference(meta)
         return meta, results
@@ -74,7 +77,7 @@ class Predictor(object):
     def visualize(self, dets, meta, class_names, score_thres, wait=0):
         time1 = time.time()
         result_img = self.model.head.show_result(
-            meta["raw_img"], dets, class_names, score_thres=score_thres, show=True
+            meta["raw_img"][0], dets, class_names, score_thres=score_thres, show=True
         )
         print("viz time: {:.3f}s".format(time.time() - time1))
         return result_img

--- a/docs/config_file_detail.md
+++ b/docs/config_file_detail.md
@@ -101,11 +101,12 @@ head:
 ```yaml
 data:
     train:
-        name: coco
+        name: CocoDataset
         img_path: coco/train2017
         ann_path: coco/annotations/instances_train2017.json
         input_size: [320,320]
         keep_ratio: True
+        multi_scale: [0.6, 1.4]
         pipeline:
     val:
     .....
@@ -116,6 +117,7 @@ In `data` you need to set your train and validate dataset.
 `name`: Dataset format name. You can create your own dataset format in `nanodet/data/dataset`.
 `input_size`: [width, height]
 `keep_ratio`: whether to maintain the original image ratio when resizing to input size
+`multi_scale`: Scaling range for multi-scale training. Set to None to turn off.
 `pipeline`: data preprocessing and augmentation pipeline
 
 ## Device

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,0 +1,20 @@
+# Update Notes
+
+* [2021.08.28] Refactor data processing pipeline and support multi-scale training (#311).
+
+* [2021.05.30] Release ncnn int8 models, and new pre-trained models with ShuffleNetV2-1.5x backbone. Much higher mAP but still realtime(**26.8mAP 21.53ms**).
+
+* [2021.03.12] Apply the **Transformer** encoder to NanoDet! Introducing **NanoDet-t**, which replaces the PAN in NanoDet-m with a **TAN(Transformer Attention Net)**,  gets 21.7 mAP(+1.1) on COCO val 2017. Check [nanodet-t.yml](config/Transformer/nanodet-t.yml) for more details.
+
+* [2021.03.03] Update **Nanodet-m-416** COCO pretrained model. **COCO mAP(0.5:0.95)=23.5**. Download in [Model Zoo](#model-zoo).
+
+* [2021.02.03] Support [EfficientNet-Lite](https://github.com/RangiLyu/EfficientNet-Lite) and [Rep-VGG](https://github.com/DingXiaoH/RepVGG) backbone. Please check the [config folder](config/). Download models in [Model Zoo](#model-zoo)
+
+* [2021.01.10] **NanoDet-g** with lower memory access cost, which designed for edge NPU or GPU, is now available!
+  Check [config/nanodet-g.yml](config/nanodet-g.yml) and download in [Model Zoo](#model-zoo).
+
+* [2020.12.19] [MNN python and cpp demos](demo_mnn/) are available.
+
+* [2020.12.05] Support voc .xml format dataset! Refer to [config/nanodet_custom_xml_dataset.yml](config/nanodet_custom_xml_dataset.yml).
+
+* [2020.12.01] Great thanks to nihui, now you can try NanoDet running in web browser! 👉 https://nihui.github.io/ncnn-webassembly-nanodet/

--- a/nanodet/data/batch_process.py
+++ b/nanodet/data/batch_process.py
@@ -1,0 +1,37 @@
+from typing import Sequence
+
+import torch
+import torch.nn.functional as F
+
+
+def stack_batch_img(
+    img_tensors: Sequence[torch.Tensor], divisible: int = 0, pad_value: float = 0.0
+) -> torch.Tensor:
+    """
+    Args:
+        img_tensors (Sequence[torch.Tensor]):
+        divisible (int):
+        pad_value (float): value to pad
+
+    Returns:
+        torch.Tensor.
+    """
+    assert len(img_tensors) > 0
+    assert isinstance(img_tensors, (tuple, list))
+    assert divisible >= 0
+    img_heights = []
+    img_widths = []
+    for img in img_tensors:
+        assert img.shape[:-2] == img_tensors[0].shape[:-2]
+        img_heights.append(img.shape[-2])
+        img_widths.append(img.shape[-1])
+    max_h, max_w = max(img_heights), max(img_widths)
+    if divisible > 0:
+        max_h = (max_h + divisible - 1) // divisible * divisible
+        max_w = (max_w + divisible - 1) // divisible * divisible
+
+    batch_imgs = []
+    for img in img_tensors:
+        padding_size = [0, max_w - img.shape[-1], 0, max_h - img.shape[-2]]
+        batch_imgs.append(F.pad(img, padding_size, value=pad_value))
+    return torch.stack(batch_imgs, dim=0).contiguous()

--- a/nanodet/data/collate.py
+++ b/nanodet/data/collate.py
@@ -69,3 +69,14 @@ def collate_function(batch):
         return [collate_function(samples) for samples in transposed]
 
     raise TypeError(default_collate_err_msg_format.format(elem_type))
+
+
+def naive_collate(batch):
+    """Only collate dict value in to a list. E.g. meta data dict and img_info
+    dict will be collated."""
+
+    elem = batch[0]
+    if isinstance(elem, dict):
+        return {key: naive_collate([d[key] for d in batch]) for key in elem}
+    else:
+        return batch

--- a/nanodet/data/dataset/base.py
+++ b/nanodet/data/dataset/base.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import random
 from abc import ABCMeta, abstractmethod
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 from torch.utils.data import Dataset
@@ -32,28 +33,30 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
         'mask': mask
      }
     segmentation mask should decode into binary masks for each class.
-
-    :param img_path: image data folder
-    :param ann_path: annotation file path or folder
-    :param use_instance_mask: load instance segmentation data
-    :param use_seg_mask: load semantic segmentation data
-    :param use_keypoint: load pose keypoint data
-    :param load_mosaic: using mosaic data augmentation from yolov4
-    :param mode: train or val or test
+    Args:
+        img_path (str): image data folder
+        ann_path (str): annotation file path or folder
+        use_instance_mask (bool): load instance segmentation data
+        use_seg_mask (bool): load semantic segmentation data
+        use_keypoint (bool): load pose keypoint data
+        load_mosaic (bool): using mosaic data augmentation from yolov4
+        mode (str): 'train' or 'val' or 'test'
+        multi_scale (Tuple[float, float]): Multi-scale factor range.
     """
 
     def __init__(
         self,
-        img_path,
-        ann_path,
-        input_size,
-        pipeline,
-        keep_ratio=True,
-        use_instance_mask=False,
-        use_seg_mask=False,
-        use_keypoint=False,
-        load_mosaic=False,
-        mode="train",
+        img_path: str,
+        ann_path: str,
+        input_size: Tuple[int, int],
+        pipeline: Dict,
+        keep_ratio: bool = True,
+        use_instance_mask: bool = False,
+        use_seg_mask: bool = False,
+        use_keypoint: bool = False,
+        load_mosaic: bool = False,
+        mode: str = "train",
+        multi_scale: Optional[Tuple[float, float]] = None,
     ):
         assert mode in ["train", "val", "test"]
         self.img_path = img_path
@@ -65,6 +68,7 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
         self.use_seg_mask = use_seg_mask
         self.use_keypoint = use_keypoint
         self.load_mosaic = load_mosaic
+        self.multi_scale = multi_scale
         self.mode = mode
 
         self.data_info = self.get_data_info(ann_path)
@@ -82,6 +86,26 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
                     idx = self.get_another_id()
                     continue
                 return data
+
+    @staticmethod
+    def get_random_size(
+        scale_range: Tuple[float, float], image_size: Tuple[int, int]
+    ) -> Tuple[int, int]:
+        """
+        Get random image shape by multi-scale factor and image_size.
+        Args:
+            scale_range (Tuple[float, float]): Multi-scale factor range.
+                Format in [(width, height), (width, height)]
+            image_size (Tuple[int, int]): Image size. Format in (width, height).
+
+        Returns:
+            Tuple[int, int]
+        """
+        assert len(scale_range) == 2
+        scale_factor = random.uniform(*scale_range)
+        width = int(image_size[0] * scale_factor)
+        height = int(image_size[1] * scale_factor)
+        return width, height
 
     @abstractmethod
     def get_data_info(self, ann_path):

--- a/nanodet/data/dataset/coco.py
+++ b/nanodet/data/dataset/coco.py
@@ -137,7 +137,16 @@ class CocoDataset(BaseDataset):
         if self.use_keypoint:
             meta["gt_keypoints"] = ann["keypoints"]
 
-        meta = self.pipeline(meta, self.input_size)
+        input_size = self.input_size
+        if self.multi_scale:
+            input_size = self.get_random_size(self.multi_scale, input_size)
+
+        meta = self.pipeline(meta, input_size)
+
+        # print("shape:", meta["img"].shape)
+        # cv2.imshow("img", meta["img"])
+        # cv2.waitKey(0)
+
         meta["img"] = torch.from_numpy(meta["img"].transpose(2, 0, 1))
         return meta
 

--- a/nanodet/data/dataset/coco.py
+++ b/nanodet/data/dataset/coco.py
@@ -141,11 +141,7 @@ class CocoDataset(BaseDataset):
         if self.multi_scale:
             input_size = self.get_random_size(self.multi_scale, input_size)
 
-        meta = self.pipeline(meta, input_size)
-
-        # print("shape:", meta["img"].shape)
-        # cv2.imshow("img", meta["img"])
-        # cv2.waitKey(0)
+        meta = self.pipeline(self, meta, input_size)
 
         meta["img"] = torch.from_numpy(meta["img"].transpose(2, 0, 1))
         return meta

--- a/nanodet/data/transform/pipeline.py
+++ b/nanodet/data/transform/pipeline.py
@@ -13,19 +13,47 @@
 # limitations under the License.
 
 import functools
+import warnings
+from typing import Dict, Tuple
+
+from torch.utils.data import Dataset
 
 from .color import color_aug_and_norm
-from .warp import warp_and_resize
+from .warp import ShapeTransform, warp_and_resize
 
 
-class Pipeline:
+class LegacyPipeline:
     def __init__(self, cfg, keep_ratio):
+        warnings.warn(
+            "Deprecated warning! Pipeline from nanodet v0.x has been deprecated,"
+            "Please use new Pipeline and update your config!"
+        )
         self.warp = functools.partial(
             warp_and_resize, warp_kwargs=cfg, keep_ratio=keep_ratio
         )
         self.color = functools.partial(color_aug_and_norm, kwargs=cfg)
 
     def __call__(self, meta, dst_shape):
-        meta = self.warp(meta=meta, dst_shape=dst_shape)
+        meta = self.warp(meta, dst_shape=dst_shape)
+        meta = self.color(meta=meta)
+        return meta
+
+
+class Pipeline:
+    """Data process pipeline. Apply augmentation and pre-processing on
+    meta_data from dataset.
+
+    Args:
+        cfg (Dict): Data pipeline config.
+        keep_ratio (bool): Whether to keep aspect ratio when resizing image.
+
+    """
+
+    def __init__(self, cfg: Dict, keep_ratio: bool):
+        self.shape_transform = ShapeTransform(keep_ratio, **cfg)
+        self.color = functools.partial(color_aug_and_norm, kwargs=cfg)
+
+    def __call__(self, dataset: Dataset, meta: Dict, dst_shape: Tuple[int, int]):
+        meta = self.shape_transform(meta, dst_shape=dst_shape)
         meta = self.color(meta=meta)
         return meta

--- a/nanodet/model/head/gfl_head.py
+++ b/nanodet/model/head/gfl_head.py
@@ -514,22 +514,22 @@ class GFLHead(nn.Module):
         warp_matrixes = (
             meta["warp_matrix"]
             if isinstance(meta["warp_matrix"], list)
-            else [meta["warp_matrix"]]
+            else meta["warp_matrix"]
         )
         img_heights = (
             meta["img_info"]["height"].cpu().numpy()
             if isinstance(meta["img_info"]["height"], torch.Tensor)
-            else [meta["img_info"]["height"]]
+            else meta["img_info"]["height"]
         )
         img_widths = (
             meta["img_info"]["width"].cpu().numpy()
             if isinstance(meta["img_info"]["width"], torch.Tensor)
-            else [meta["img_info"]["width"]]
+            else meta["img_info"]["width"]
         )
         img_ids = (
             meta["img_info"]["id"].cpu().numpy()
             if isinstance(meta["img_info"]["id"], torch.Tensor)
-            else [meta["img_info"]["id"]]
+            else meta["img_info"]["id"]
         )
 
         for result, img_width, img_height, img_id, warp_matrix in zip(

--- a/nanodet/trainer/dist_trainer.py
+++ b/nanodet/trainer/dist_trainer.py
@@ -33,6 +33,7 @@ class DistTrainer(Trainer):
     """
 
     def run_step(self, model, batch, mode="train"):
+        batch = self._preprocess_batch_input(batch)
         output, loss, loss_stats = model.module.forward_train(batch)
         loss = loss.mean()
         if mode == "train":

--- a/tests/test_data/test_batch_process.py
+++ b/tests/test_data/test_batch_process.py
@@ -1,0 +1,18 @@
+import pytest
+import torch
+
+from nanodet.data.batch_process import stack_batch_img
+
+
+def test_stack_batch_img():
+    with pytest.raises(AssertionError):
+        dummy_imgs = [torch.rand((1, 30, 30)), torch.rand((3, 28, 10))]
+        stack_batch_img(dummy_imgs, divisible=32, pad_value=0)
+
+    dummy_imgs = [
+        torch.rand((3, 300, 300)),
+        torch.rand((3, 288, 180)),
+        torch.rand((3, 169, 256)),
+    ]
+    batch_tensor = stack_batch_img(dummy_imgs, divisible=32, pad_value=0)
+    assert batch_tensor.shape == (3, 3, 320, 320)

--- a/tests/test_data/test_dataset/test_cocodataset.py
+++ b/tests/test_data/test_dataset/test_cocodataset.py
@@ -17,11 +17,18 @@ def test_cocodataset():
     assert isinstance(dataset, CocoDataset)
 
     for i, data in enumerate(dataset):
-        assert data["img"].shape == (3, 320, 320)
+        assert data["img"].shape == (3, 320, 285)
         for mask in data["gt_masks"]:
-            assert mask.shape == (320, 320)
+            assert mask.shape == (320, 285)
 
     dataset = build_dataset(cfg, "val")
+    for i, data in enumerate(dataset):
+        assert data["img"].shape == (3, 320, 285)
+        for mask in data["gt_masks"]:
+            assert mask.shape == (320, 285)
+
+    cfg["keep_ratio"] = False
+    dataset = build_dataset(cfg, "train")
     for i, data in enumerate(dataset):
         assert data["img"].shape == (3, 320, 320)
         for mask in data["gt_masks"]:
@@ -29,3 +36,22 @@ def test_cocodataset():
 
     with pytest.raises(AssertionError):
         build_dataset(cfg, "2333")
+
+
+def test_multi_scale():
+    cfg = dict(
+        name="CocoDataset",
+        img_path="./tests/data",
+        ann_path="./tests/data/dummy_coco.json",
+        input_size=[320, 320],  # [w,h]
+        multi_scale=[1.5, 1.5],
+        keep_ratio=True,
+        use_instance_mask=True,
+        pipeline=dict(normalize=[[103.53, 116.28, 123.675], [57.375, 57.12, 58.395]]),
+    )
+    dataset = build_dataset(cfg, "train")
+
+    for i, data in enumerate(dataset):
+        assert data["img"].shape == (3, 480, 427)
+        for mask in data["gt_masks"]:
+            assert mask.shape == (480, 427)

--- a/tests/test_data/test_dataset/test_xmldataset.py
+++ b/tests/test_data/test_dataset/test_xmldataset.py
@@ -3,7 +3,7 @@ import pytest
 from nanodet.data.dataset import XMLDataset, build_dataset
 
 
-def test_cocodataset():
+def test_xmldataset():
     class_names = ["asuka", "head"]
     cfg = dict(
         name="XMLDataset",
@@ -18,11 +18,11 @@ def test_cocodataset():
     assert isinstance(dataset, XMLDataset)
 
     for i, data in enumerate(dataset):
-        assert data["img"].shape == (3, 320, 320)
+        assert data["img"].shape == (3, 320, 285)
 
     dataset = build_dataset(cfg, "val")
     for i, data in enumerate(dataset):
-        assert data["img"].shape == (3, 320, 320)
+        assert data["img"].shape == (3, 320, 285)
 
     with pytest.raises(AssertionError):
         build_dataset(cfg, "2333")

--- a/tests/test_data/test_transform/test_warp.py
+++ b/tests/test_data/test_transform/test_warp.py
@@ -3,6 +3,7 @@ import copy
 import numpy as np
 
 from nanodet.data.transform.warp import (
+    ShapeTransform,
     get_flip_matrix,
     get_perspective_matrix,
     get_rotation_matrix,
@@ -77,3 +78,24 @@ def test_warp():
     assert np.array_equal(
         res["gt_bboxes"], np.array([[0, 75, 30, 105]], dtype=np.float32)
     )
+
+
+def test_shape_transform():
+    dummy_meta = dict(
+        img=np.random.randint(0, 255, size=(100, 200, 3), dtype=np.uint8),
+        gt_bboxes=np.array([[0, 0, 20, 20]]),
+        gt_masks=[np.zeros((100, 200), dtype=np.uint8)],
+    )
+    # keep ratio
+    transform = ShapeTransform(keep_ratio=True, divisible=32)
+    res = transform(dummy_meta, dst_shape=(50, 50))
+    assert np.array_equal(
+        res["gt_bboxes"], np.array([[0, 0, 6.4, 6.4]], dtype=np.float32)
+    )
+    assert res["img"].shape[0] % 32 == 0
+    assert res["img"].shape[1] % 32 == 0
+
+    # not keep ratio
+    transform = ShapeTransform(keep_ratio=False)
+    res = transform(dummy_meta, dst_shape=(50, 50))
+    assert np.array_equal(res["gt_bboxes"], np.array([[0, 0, 5, 10]], dtype=np.float32))

--- a/tools/deprecated/test.py
+++ b/tools/deprecated/test.py
@@ -20,7 +20,7 @@ import warnings
 
 import torch
 
-from nanodet.data.collate import collate_function
+from nanodet.data.collate import naive_collate
 from nanodet.data.dataset import build_dataset
 from nanodet.evaluator import build_evaluator
 from nanodet.model.arch import build_model
@@ -72,7 +72,7 @@ def main(args):
         shuffle=False,
         num_workers=cfg.device.workers_per_gpu,
         pin_memory=True,
-        collate_fn=collate_function,
+        collate_fn=naive_collate,
         drop_last=False,
     )
     trainer = build_trainer(local_rank, cfg, model, logger)

--- a/tools/deprecated/train.py
+++ b/tools/deprecated/train.py
@@ -19,7 +19,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
-from nanodet.data.collate import collate_function
+from nanodet.data.collate import naive_collate
 from nanodet.data.dataset import build_dataset
 from nanodet.evaluator import build_evaluator
 from nanodet.model.arch import build_model
@@ -85,7 +85,7 @@ def main(args):
             batch_size=cfg.device.batchsize_per_gpu,
             num_workers=cfg.device.workers_per_gpu,
             pin_memory=True,
-            collate_fn=collate_function,
+            collate_fn=naive_collate,
             sampler=train_sampler,
             drop_last=True,
         )
@@ -96,7 +96,7 @@ def main(args):
             shuffle=True,
             num_workers=cfg.device.workers_per_gpu,
             pin_memory=True,
-            collate_fn=collate_function,
+            collate_fn=naive_collate,
             drop_last=True,
         )
 
@@ -106,7 +106,7 @@ def main(args):
         shuffle=False,
         num_workers=cfg.device.workers_per_gpu,
         pin_memory=True,
-        collate_fn=collate_function,
+        collate_fn=naive_collate,
         drop_last=False,
     )
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -20,7 +20,7 @@ import warnings
 import pytorch_lightning as pl
 import torch
 
-from nanodet.data.collate import collate_function
+from nanodet.data.collate import naive_collate
 from nanodet.data.dataset import build_dataset
 from nanodet.evaluator import build_evaluator
 from nanodet.trainer.task import TrainingTask
@@ -60,7 +60,7 @@ def main(args):
         shuffle=False,
         num_workers=cfg.device.workers_per_gpu,
         pin_memory=True,
-        collate_fn=collate_function,
+        collate_fn=naive_collate,
         drop_last=False,
     )
     evaluator = build_evaluator(cfg.evaluator, val_dataset)

--- a/tools/train.py
+++ b/tools/train.py
@@ -20,7 +20,7 @@ import pytorch_lightning as pl
 import torch
 from pytorch_lightning.callbacks import ProgressBar
 
-from nanodet.data.collate import collate_function
+from nanodet.data.collate import naive_collate
 from nanodet.data.dataset import build_dataset
 from nanodet.evaluator import build_evaluator
 from nanodet.trainer.task import TrainingTask
@@ -76,7 +76,7 @@ def main(args):
         shuffle=True,
         num_workers=cfg.device.workers_per_gpu,
         pin_memory=True,
-        collate_fn=collate_function,
+        collate_fn=naive_collate,
         drop_last=True,
     )
     val_dataloader = torch.utils.data.DataLoader(
@@ -85,7 +85,7 @@ def main(args):
         shuffle=False,
         num_workers=cfg.device.workers_per_gpu,
         pin_memory=True,
-        collate_fn=collate_function,
+        collate_fn=naive_collate,
         drop_last=False,
     )
 


### PR DESCRIPTION
# Refactor data pipeline

## 1. Add naive_collate
Replace old collate function with naive_collate. naive_collate only merge meta data dict values into a list from per-image's meta data which load from dataloader workers. Stacking image tensor is moved to the training task.

## 2. Add stack_batch_img
This function will pad all image tensor into same shape and then stack them into a batch tensor.

## 3. Support scaling image instead of resizing into a fix shape.

## 4. Support multi-scale training
Usage: Add multi_scale to `data.train`
```yaml
data:
  train:
    name: CocoDataset
    img_path: coco/train2017
    ann_path: coco/annotations/instances_train2017.json
    input_size: [320,320] # [w,h]
    multi_scale: [0.6, 1.4] # scale factor range of multi-scale training
```