### PR TITLE
PyMNNInterpreter_getSessionOutput: Get output failed - Solved

### DIFF
--- a/demo_mnn/python/demo_mnn.py
+++ b/demo_mnn/python/demo_mnn.py
@@ -682,9 +682,9 @@ class NanoDetMNN(NanoDetABC):
         self.input_tensor.copyFrom(tmp_input)
         self.interpreter.runSession(self.session)
         score_out_name = [
-            "cls_pred_stride_8",
-            "cls_pred_stride_16",
-            "cls_pred_stride_32",
+            "792",
+            "814",
+            "836",
         ]
         scores = [
             self.interpreter.getSessionOutput(self.session, x).getData()
@@ -692,9 +692,9 @@ class NanoDetMNN(NanoDetABC):
         ]
         scores = [np.reshape(x, (-1, 80)) for x in scores]
         boxes_out_name = [
-            "dis_pred_stride_8",
-            "dis_pred_stride_16",
-            "dis_pred_stride_32",
+            "795",
+            "817",
+            "839",
         ]
         raw_boxes = [
             self.interpreter.getSessionOutput(self.session, x).getData()


### PR DESCRIPTION
When 

`score_out_name = [ "cls_pred_stride_8",  "cls_pred_stride_16", "cls_pred_stride_32"]`

`boxes_out_name = [ "dis_pred_stride_8",  "dis_pred_stride_16", "dis_pred_stride_32"]`

Then below error was occuring

Using MNN as inference backend
Using weight: ../../../nanodet-320.mnn
find 2 images
  0%|                                                                              | 0/2 [00:00<?, ?it/s]Error: can't find output: cls_pred_stride_8
  0%|                                                                              | 0/2 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "demo_mnn.py", line 811, in <module>
    main()
  File "demo_mnn.py", line 797, in main
    detector.detect_folder(args.img_fold, args.result_fold)
  File "demo_mnn.py", line 655, in detect_folder
    bbox, label, score = self.detect(img)
  File "demo_mnn.py", line 620, in detect
    scores, raw_boxes = self.infer_image(img_input)
  File "demo_mnn.py", line 689, in infer_image
    scores = [
  File "demo_mnn.py", line 690, in <listcomp>
    self.interpreter.getSessionOutput(self.session, x).getData()
Exception: PyMNNInterpreter_getSessionOutput: Get output failed

The solution was to give the string number

