### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/demo_mnn/README.md
+++ b/demo_mnn/README.md
@@ -63,7 +63,7 @@ make
 Note that a flag at `main.cpp` is used to control whether to show the detection result or save it into a fold.
 
 ``` c++
-#define __SAVE_RESULT__ // if defined save drawed results to ../results, else show it in windows
+#define __SAVE_RESULT__ // if defined save drawn results to ../results, else show it in windows
 ```
 
 ## Run

--- a/demo_mnn/main.cpp
+++ b/demo_mnn/main.cpp
@@ -4,7 +4,7 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
-#define __SAVE_RESULT__ // if defined save drawed results to ../results, else show it in windows
+#define __SAVE_RESULT__ // if defined save drawn results to ../results, else show it in windows
 
 struct object_rect {
     int x;

--- a/docs/config_file_detail.md
+++ b/docs/config_file_detail.md
@@ -21,7 +21,7 @@ model:
         head: xxx
 ```
 
-Most detection model architecture can be devided into 3 parts: backbone, task head and connector between them(e.g. FPN, BiFPN, PAN...).
+Most detection model architecture can be divided into 3 parts: backbone, task head and connector between them(e.g. FPN, BiFPN, PAN...).
 
 ### Backbone
 

--- a/nanodet/data/dataset/coco.py
+++ b/nanodet/data/dataset/coco.py
@@ -127,7 +127,7 @@ class CocoDataset(BaseDataset):
         img = cv2.imread(image_path)
         if img is None:
             print("image {} read failed.".format(image_path))
-            raise FileNotFoundError("Cant load image! Please check image path!")
+            raise FileNotFoundError("Can't load image! Please check image path!")
         ann = self.get_img_annotation(idx)
         meta = dict(
             img=img, img_info=img_info, gt_bboxes=ann["bboxes"], gt_labels=ann["labels"]

--- a/nanodet/model/head/assigner/assign_result.py
+++ b/nanodet/model/head/assigner/assign_result.py
@@ -115,7 +115,7 @@ class AssignResult(util_mixins.NiceRepr):
         Args:
             num_preds: number of predicted boxes
             num_gts: number of true boxes
-            p_ignore (float): probability of a predicted box assinged to an
+            p_ignore (float): probability of a predicted box assigned to an
                 ignored truth
             p_assigned (float): probability of a predicted box not being
                 assigned

--- a/nanodet/model/head/assigner/atss_assigner.py
+++ b/nanodet/model/head/assigner/atss_assigner.py
@@ -53,7 +53,7 @@ class ATSSAssigner(BaseAssigner):
         4. get corresponding iou for the these candidates, and compute the
            mean and std, set mean + std as the iou threshold
         5. select these candidates whose iou are greater than or equal to
-           the threshold as postive
+           the threshold as positive
         6. limit the positive sample's center in gt
 
 

--- a/nanodet/model/head/gfl_head.py
+++ b/nanodet/model/head/gfl_head.py
@@ -695,7 +695,7 @@ class GFLHead(nn.Module):
 
     def grid_cells_to_center(self, grid_cells):
         """
-        Get center location of each gird cell
+        Get center location of each grid cell
         :param grid_cells: grid cells of a feature map
         :return: center points
         """

--- a/nanodet/model/loss/iou_loss.py
+++ b/nanodet/model/loss/iou_loss.py
@@ -74,7 +74,7 @@ def bbox_overlaps(bboxes1, bboxes2, mode="iou", is_aligned=False, eps=1e-6):
     """
 
     assert mode in ["iou", "iof", "giou"], f"Unsupported mode {mode}"
-    # Either the boxes are empty or the length of boxes's last dimenstion is 4
+    # Either the boxes are empty or the length of boxes's last dimension is 4
     assert bboxes1.size(-1) == 4 or bboxes1.size(0) == 0
     assert bboxes2.size(-1) == 4 or bboxes2.size(0) == 0
 

--- a/nanodet/model/loss/utils.py
+++ b/nanodet/model/loss/utils.py
@@ -30,7 +30,7 @@ def weight_reduce_loss(loss, weight=None, reduction="mean", avg_factor=None):
         loss (Tensor): Element-wise loss.
         weight (Tensor): Element-wise weights.
         reduction (str): Same as built-in losses of PyTorch.
-        avg_factor (float): Avarage factor when computing the mean of losses.
+        avg_factor (float): Average factor when computing the mean of losses.
 
     Returns:
         Tensor: Processed loss values.

--- a/nanodet/util/flops_counter.py
+++ b/nanodet/util/flops_counter.py
@@ -224,7 +224,7 @@ def print_model_with_flops(
         >>>     return x
         >>> model = ExampleModel()
         >>> x = (3, 16, 16)
-        to print the complexity inforamtion state for each layer, you can use
+        to print the complexity information state for each layer, you can use
         >>> get_model_complexity_info(model, x)
         or directly use
         >>> print_model_with_flops(model, 4579784.0, 37361)

--- a/nanodet/util/yacs.py
+++ b/nanodet/util/yacs.py
@@ -68,7 +68,7 @@ class CfgNode(dict):
     def __init__(self, init_dict=None, key_list=None, new_allowed=False):
         """
         Args:
-            init_dict (dict): the possibly-nested dictionary to initailize the
+            init_dict (dict): the possibly-nested dictionary to initialize the
                 CfgNode.
             key_list (list[str]): a list of names which index this CfgNode from
                 the root.
@@ -171,8 +171,8 @@ class CfgNode(dict):
         r = ""
         s = []
         for k, v in sorted(self.items()):
-            seperator = "\n" if isinstance(v, CfgNode) else " "
-            attr_str = "{}:{}{}".format(str(k), seperator, str(v))
+            separator = "\n" if isinstance(v, CfgNode) else " "
+            attr_str = "{}:{}{}".format(str(k), separator, str(v))
             attr_str = _indent(attr_str, 2)
             s.append(attr_str)
         r += "\n".join(s)

--- a/tools/export_onnx.py
+++ b/tools/export_onnx.py
@@ -72,7 +72,7 @@ def parse_args():
         "--out_path", type=str, default="nanodet.onnx", help="Onnx model output path."
     )
     parser.add_argument(
-        "--input_shape", type=str, default=None, help="Model intput shape."
+        "--input_shape", type=str, default=None, help="Model input shape."
     )
     return parser.parse_args()
 


### PR DESCRIPTION
[`codespell --skip="*.ipynb"`](https://pypi.org/project/codespell/)