### PR TITLE
update annotation of input size in demo_ncnn

### DIFF
--- a/demo_ncnn/nanodet.h
+++ b/demo_ncnn/nanodet.h
@@ -44,7 +44,7 @@ public:
     ncnn::Net* Net;
     static bool hasGPU;
     // modify these parameters to the same with your config if you want to use your own model
-    int input_size[2] = {416, 416}; // input height and width
+    int input_size[2] = {416, 416}; // input size {width, height}
     int num_class = 80; // number of classes. 80 for COCO
     int reg_max = 7; // `reg_max` set in the training config. Default: 7.
     std::vector<int> strides = { 8, 16, 32, 64 }; // strides of the multi-level feature.


### PR DESCRIPTION
update annotation of input size in demo_ncnn/nanodet.h to avoid ambiguity.