### PR TITLE
Add Weights and Baises Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ https://nihui.github.io/ncnn-webassembly-nanodet/
 
 First, install requirements and setup NanoDet following installation guide. Then download COCO pretrain weight from here
 
-👉[COCO pretrain weight (Google Drive)](https://github.com/RangiLyu/nanodet/releases/download/v1.0.0-alpha/nanodet-plus-m_416_checkpoint.ckpt)
+👉[COCO pretrain checkpoint](https://github.com/RangiLyu/nanodet/releases/download/v1.0.0-alpha-1/nanodet-plus-m_416_checkpoint.ckpt)
 
 The pre-trained weight was trained by the config `config/nanodet-plus-m_416.yml`.
 

--- a/nanodet/trainer/task.py
+++ b/nanodet/trainer/task.py
@@ -77,6 +77,7 @@ class TrainingTask(LightningModule):
         preds, loss, loss_states = self.model.forward_train(batch)
 
         # log train losses
+        log_dict = {}
         if self.global_step % self.cfg.log.interval == 0:
             lr = self.optimizers().param_groups[0]["lr"]
             log_msg = "Train|Epoch{}/{}|Iter{}({})| lr:{:.2e}| ".format(
@@ -97,8 +98,10 @@ class TrainingTask(LightningModule):
                     loss_states[loss_name].mean().item(),
                     self.global_step,
                 )
+                log_dict[loss_name] = loss_states[loss_name].mean().item()
+            log_dict["lr"] = lr
             self.logger.info(log_msg)
-
+            self.logger.log_metrics(log_dict, self.global_step, prefix="")
         return loss
 
     def training_epoch_end(self, outputs: List[Any]) -> None:

--- a/nanodet/trainer/task.py
+++ b/nanodet/trainer/task.py
@@ -180,7 +180,8 @@ class TrainingTask(LightningModule):
             self.logger.log_metrics(eval_results, self.current_epoch + 1)
         else:
             self.logger.info("Skip val on rank {}".format(self.local_rank))
-        self.logger._log_eval_table(all_results, self.cfg)
+        if self.logger._wandb_logger:
+            self.logger._log_eval_table(all_results, self.cfg)
 
     def test_step(self, batch, batch_idx):
         dets = self.predict(batch, batch_idx)

--- a/nanodet/trainer/task.py
+++ b/nanodet/trainer/task.py
@@ -46,17 +46,12 @@ class TrainingTask(LightningModule):
         self.evaluator = evaluator
         self.save_flag = -10
         self.log_style = "NanoDet"
-        self.num_eval_samples = 16
         self.weight_averager = None
         if "weight_averager" in cfg.model:
             self.weight_averager = build_weight_averager(
                 cfg.model.weight_averager, device=self.device
             )
             self.avg_model = copy.deepcopy(self.model)
-            
-        if len(cfg.device.gpu_ids) > 1:
-            self.num_eval_samples = self.num_eval_samples // cfg.device.gpu_ids
-
 
     def _preprocess_batch_input(self, batch):
         batch_imgs = batch["img"]
@@ -136,23 +131,8 @@ class TrainingTask(LightningModule):
             self.logger.info(log_msg)
 
         dets = self.model.head.post_process(preds, batch)
-        if self.logger._wandb_logger and len(self.logger._eval_samples) < self.num_eval_samples:
-            required_samples = max(0,self.num_eval_samples - len(self.logger._eval_samples))
-            max_len = min(required_samples, len(batch['img']))
-                
-            for i, img_name in enumerate(batch['img'][:max_len]):
-                img_id = batch['img_info']['id'][i]
-                img_name = batch['img_info']['file_name'][i]
-                img_dets = dets[img_id]
-                img_path = os.path.join(self.cfg.data.val.img_path, img_name)
-                classes = self.cfg.class_names
-                
-                self.logger._log_eval_sample(sample_id=img_id,
-                                             sample_path=img_path,
-                                             preds=img_dets,
-                                             classes=classes)
-
         return dets
+
 
     def validation_epoch_end(self, validation_step_outputs):
         """
@@ -200,7 +180,7 @@ class TrainingTask(LightningModule):
             self.logger.log_metrics(eval_results, self.current_epoch + 1)
         else:
             self.logger.info("Skip val on rank {}".format(self.local_rank))
-        self.logger._log_eval_table(self.cfg.class_names)
+        self.logger._log_eval_table(all_results, self.cfg)
 
     def test_step(self, batch, batch_idx):
         dets = self.predict(batch, batch_idx)

--- a/nanodet/util/logger.py
+++ b/nanodet/util/logger.py
@@ -114,16 +114,17 @@ class AverageMeter(object):
 class NanoDetLightningLogger(LightningLoggerBase):
     def __init__(self, save_dir="./", use_wandb=True, **kwargs):
         super().__init__()
-        self._name = "NanoDet" or kwargs.get("name", None)
+        self._name = "NanoDet" or kwargs.pop("name", None)
         self._version = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
         self.log_dir = os.path.join(save_dir, f"logs-{self._version}")
-        self._kwargs = kwargs
 
         self._fs = get_filesystem(save_dir)
         self._fs.makedirs(self.log_dir, exist_ok=True)
         self._init_logger()
-        self._wandb_logger = self._init_wandb() if use_wandb else None
+        self._wandb_logger = self._init_wandb(kwargs.pop("wandb_args",{})) if use_wandb else None
         self._experiment = None
+        self._kwargs = kwargs
+
 
     @property
     def name(self):

--- a/nanodet/util/logger.py
+++ b/nanodet/util/logger.py
@@ -224,7 +224,7 @@ class NanoDetLightningLogger(LightningLoggerBase):
             self.experiment.add_scalars(prefix + k, {"Val": v}, step)
         if self._wandb_logger:
             log_dict = {prefix + k: v for k, v in metrics.items()}
-            self._wandb_logger.experiment.log(log_dict)
+            self._wandb_logger.log_metrics(log_dict, step=step)
 
     @rank_zero_only
     def save(self):

--- a/nanodet/util/logger.py
+++ b/nanodet/util/logger.py
@@ -194,8 +194,7 @@ class NanoDetLightningLogger(LightningLoggerBase):
         self.logger.addHandler(ch)
     
     @rank_zero_only
-    def _init_wandb(self) -> None:
-        wandb_args = self._kwargs.get("wandb_args", {})
+    def _init_wandb(self, wandb_args) -> None:
         wandb_logger = WandbLogger(project=self._name, **wandb_args)
         wandb_logger.experiment._label(repo="nanodet")
         return wandb_logger

--- a/nanodet/util/logger.py
+++ b/nanodet/util/logger.py
@@ -114,7 +114,7 @@ class AverageMeter(object):
 class NanoDetLightningLogger(LightningLoggerBase):
     def __init__(self, save_dir="./", use_wandb=True, **kwargs):
         super().__init__()
-        self._name = "NanoDet" or kwargs.pop("name", None)
+        self._name = kwargs.pop("name", None) or "NanoDet"
         self._version = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
         self.log_dir = os.path.join(save_dir, f"logs-{self._version}")
 
@@ -155,7 +155,6 @@ class NanoDetLightningLogger(LightningLoggerBase):
                 "the dependencies to use torch.utils.tensorboard "
                 "(applicable to PyTorch 1.1 or higher)"
             ) from None
-
         self._experiment = SummaryWriter(log_dir=self.log_dir, **self._kwargs)
         return self._experiment
 

--- a/nanodet/util/logger.py
+++ b/nanodet/util/logger.py
@@ -112,7 +112,7 @@ class AverageMeter(object):
 
 
 class NanoDetLightningLogger(LightningLoggerBase):
-    def __init__(self, save_dir="./", use_wandb=True, **kwargs):
+    def __init__(self, save_dir="./", use_wandb=False, **kwargs):
         super().__init__()
         self._name = kwargs.pop("name", None) or "NanoDet"
         self._version = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
@@ -234,4 +234,6 @@ class NanoDetLightningLogger(LightningLoggerBase):
     def finalize(self, status):
         self.experiment.flush()
         self.experiment.close()
+        if self._wandb_logger:
+            self._wandb_logger.experiment.finish()
         self.save()

--- a/nanodet/util/logger.py
+++ b/nanodet/util/logger.py
@@ -126,7 +126,8 @@ class NanoDetLightningLogger(LightningLoggerBase):
         self._experiment = None
         self._num_eval_samples = num_eval_samples
         self._id_to_name = None
-        self._wandb_logger = self._init_wandb(kwargs.pop("wandb_args",{})) if use_wandb else None
+        wandb_args = kwargs.pop("wandb_args",{})
+        self._wandb_logger = self._init_wandb(wandb_args) if use_wandb else None
         self._kwargs = kwargs
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ torch>=1.7
 torchmetrics
 torchvision
 tqdm
+wandb

--- a/tests/test_utils/test_logger.py
+++ b/tests/test_utils/test_logger.py
@@ -7,7 +7,7 @@ from nanodet.util import NanoDetLightningLogger, cfg, load_config
 
 def test_logger():
     tmp_dir = tempfile.TemporaryDirectory()
-    logger = NanoDetLightningLogger(tmp_dir.name)
+    logger = NanoDetLightningLogger(tmp_dir.name, use_wandb=True, wandb_args={"anonymous":"must"})
 
     writer = logger.experiment
     assert isinstance(writer, SummaryWriter)

--- a/tools/train.py
+++ b/tools/train.py
@@ -60,7 +60,10 @@ def main(args):
     torch.backends.cudnn.benchmark = True
     mkdir(local_rank, cfg.save_dir)
 
-    logger = NanoDetLightningLogger(cfg.save_dir, args.use_wandb, wandb_args={"config": cfg})
+    logger = NanoDetLightningLogger(cfg.save_dir,
+                                    args.use_wandb,
+                                    num_eval_samples=50,
+                                    wandb_args={"config": cfg}, name="nanodet-testing")
     logger.dump_cfg(cfg)
 
     if args.seed is not None:

--- a/tools/train.py
+++ b/tools/train.py
@@ -41,7 +41,9 @@ def parse_args():
         "--local_rank", default=-1, type=int, help="node rank for distributed training"
     )
     parser.add_argument("--seed", type=int, default=None, help="random seed")
-    parser.add_argument('--use-wandb', action='store_true', help='use wandb logger')
+    parser.add_argument('--use-wandb', action='store_true', help="use wandb logger")
+    parser.add_argument(
+        "--eval-samples", type=int, default=16, help="number of evaluation samples to log")
     args = parser.parse_args()
     return args
 
@@ -62,7 +64,7 @@ def main(args):
 
     logger = NanoDetLightningLogger(cfg.save_dir,
                                     args.use_wandb,
-                                    num_eval_samples=50,
+                                    num_eval_samples=args.eval_samples,
                                     wandb_args={"config": cfg}, name="nanodet-testing")
     logger.dump_cfg(cfg)
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -41,6 +41,7 @@ def parse_args():
         "--local_rank", default=-1, type=int, help="node rank for distributed training"
     )
     parser.add_argument("--seed", type=int, default=None, help="random seed")
+    parser.add_argument('--use_wandb', action='store_true', help='use wandb logger')
     args = parser.parse_args()
     return args
 
@@ -59,7 +60,7 @@ def main(args):
     torch.backends.cudnn.benchmark = True
     mkdir(local_rank, cfg.save_dir)
 
-    logger = NanoDetLightningLogger(cfg.save_dir)
+    logger = NanoDetLightningLogger(cfg.save_dir, args.use_wandb)
     logger.dump_cfg(cfg)
 
     if args.seed is not None:

--- a/tools/train.py
+++ b/tools/train.py
@@ -41,7 +41,7 @@ def parse_args():
         "--local_rank", default=-1, type=int, help="node rank for distributed training"
     )
     parser.add_argument("--seed", type=int, default=None, help="random seed")
-    parser.add_argument('--use_wandb', action='store_true', help='use wandb logger')
+    parser.add_argument('--use-wandb', action='store_true', help='use wandb logger')
     args = parser.parse_args()
     return args
 
@@ -60,7 +60,7 @@ def main(args):
     torch.backends.cudnn.benchmark = True
     mkdir(local_rank, cfg.save_dir)
 
-    logger = NanoDetLightningLogger(cfg.save_dir, args.use_wandb)
+    logger = NanoDetLightningLogger(cfg.save_dir, args.use_wandb, wandb_args={"config": cfg})
     logger.dump_cfg(cfg)
 
     if args.seed is not None:


### PR DESCRIPTION
This PR adds support for Weights and Biases Metric and evaluation logging.
## How to use?
* pass `--use-wandb` flag with `tools/train.py`
* Set number of interactive evaluations samples to be logged at each validation step by setting `--eval-samples <int>` 
## Tables
Tables Inspect, filter, query, and compare your model prediction to better debug
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/15766192/142981588-feb8c773-ec56-495f-910e-ad5165496aa3.gif)

In the current implementation, the wandb arguments and directly passed in the Base Logger. We can refactor it out into a more suitable place if needed. There are more points of integration such as model checkpointing on cloud, interactive inference logging which can be built on top of this