### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ opencv-python
 pyaml
 pycocotools
 pytorch-lightning>=1.4.0
+omegaconf>=2.0.1
 tensorboard
 termcolor
 torch>=1.7


### PR DESCRIPTION
Latest pytorch-lightning require omegaconf>=2.0.1, or it will report error `cannot import name 'UnsupportedValueType' from 'omegaconf.errors'`, see https://github.com/PyTorchLightning/pytorch-lightning/issues/7110