### PR TITLE
add notes for the missed step in linux compiling

### DIFF
--- a/demo_ncnn/README.md
+++ b/demo_ncnn/README.md
@@ -53,6 +53,8 @@ git clone --recursive https://github.com/Tencent/ncnn.git
 
 Build NCNN following this tutorial: [Build for Linux / NVIDIA Jetson / Raspberry Pi](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-linux)
 
+Note: Don't forget to make install the ncnn after you finished compiling it.
+
 ### Step4.
 
 Set environment variables. Run:


### PR DESCRIPTION
The compile step in the [ncnn documents](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-linux) don't tell us to make install it after compilation finished.
Nor the document in the demo_ncnn.
So add the note here.