### PR TITLE
修复误删文件的BUG

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -131,7 +131,7 @@ def main():
         )
         mkdir(local_rank, save_folder)
         save_path = (
-            os.path.join(save_folder, args.path.split("/")[-1])
+            os.path.join(save_folder, args.path.replace("\\","/").split("/")[-1])
             if args.demo == "video"
             else os.path.join(save_folder, "camera.mp4")
         )


### PR DESCRIPTION
运行： python demo/demo_copy.py video --config config\nanodet-plus-m-1.5x_416.yml --model nanodet-plus-m-1.5x_416_checkpoint.ckpt --path D:\TestData\testvedio-1.mp4

运行上述指令后，因为我的  --path “路径” 是用“\”分隔的，导致源代码分割失败，直接在我原始文件上写入数据。

demo运行失败不说，
还导致原始视频文件被覆盖写入，变成1kb， 数据全部丢失。（还好有备份~~！）

修改后增加填写路径的兼容性，以及避免文件被误删！