### PR TITLE
Fixes a couple of issues to add fp16 training support

### DIFF
--- a/nanodet/model/head/assigner/dsl_assigner.py
+++ b/nanodet/model/head/assigner/dsl_assigner.py
@@ -91,9 +91,9 @@ class DynamicSoftLabelAssigner(BaseAssigner):
         valid_pred_scores = valid_pred_scores.unsqueeze(1).repeat(1, num_gt, 1)
 
         soft_label = gt_onehot_label * pairwise_ious[..., None]
-        scale_factor = soft_label - valid_pred_scores
+        scale_factor = soft_label - valid_pred_scores.sigmoid()
 
-        cls_cost = F.binary_cross_entropy(
+        cls_cost = F.binary_cross_entropy_with_logits(
             valid_pred_scores, soft_label, reduction="none"
         ) * scale_factor.abs().pow(2.0)
 

--- a/nanodet/model/head/nanodet_plus_head.py
+++ b/nanodet/model/head/nanodet_plus_head.py
@@ -312,7 +312,7 @@ class NanoDetPlusHead(nn.Module):
             return labels, label_scores, bbox_targets, dist_targets, 0
 
         assign_result = self.assigner.assign(
-            cls_preds.sigmoid(), center_priors, decoded_bboxes, gt_bboxes, gt_labels
+            cls_preds, center_priors, decoded_bboxes, gt_bboxes, gt_labels
         )
         pos_inds, neg_inds, pos_gt_bboxes, pos_assigned_gt_inds = self.sample(
             assign_result, gt_bboxes

--- a/nanodet/util/config.py
+++ b/nanodet/util/config.py
@@ -14,6 +14,7 @@ cfg.data = CfgNode(new_allowed=True)
 cfg.data.train = CfgNode(new_allowed=True)
 cfg.data.val = CfgNode(new_allowed=True)
 cfg.device = CfgNode(new_allowed=True)
+cfg.device.precision = 32
 # train
 cfg.schedule = CfgNode(new_allowed=True)
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -113,9 +113,9 @@ def main(args):
     )
     if cfg.device.gpu_ids == -1:
         logger.info("Using CPU training")
-        accelerator, devices, strategy = "cpu", None, None
+        accelerator, devices, strategy, precision = "cpu", None, None, cfg.device.precision
     else:
-        accelerator, devices, strategy = "gpu", cfg.device.gpu_ids, None
+        accelerator, devices, strategy, precision = "gpu", cfg.device.gpu_ids, None, cfg.device.precision
 
     if devices and len(devices) > 1:
         strategy = "ddp"
@@ -135,6 +135,7 @@ def main(args):
         benchmark=cfg.get("cudnn_benchmark", True),
         gradient_clip_val=cfg.get("grad_clip", 0.0),
         strategy=strategy,
+        precision=precision,
     )
 
     trainer.fit(task, train_dataloader, val_dataloader)


### PR DESCRIPTION
There were a couple of issues when trying to use `fp16` training. For one was that it was not exposed through the configuration system. The other was that the `DynamicSoftLabelAssigner` used `binary_cross_entropy` instead of `binary_cross_entropy_with_logits`. This changes where `sigmoid` is called on the predictions so that the more stable `binary_cross_entropy_with_logits` can be used and the `Trainer` can be configured to use `fp16` precision.