### PR TITLE
Fix RuntimeError due to inplace operation (fpn.py)

### DIFF
--- a/nanodet/model/fpn/fpn.py
+++ b/nanodet/model/fpn/fpn.py
@@ -76,16 +76,20 @@ class FPN(nn.Module):
         assert len(inputs) == len(self.in_channels)
 
         # build laterals
-        laterals = [
+        laterals_ = [
             lateral_conv(inputs[i + self.start_level])
             for i, lateral_conv in enumerate(self.lateral_convs)
         ]
 
         # build top-down path
-        used_backbone_levels = len(laterals)
+        used_backbone_levels = len(laterals_)
+        laterals = [laterals_[-1]]
         for i in range(used_backbone_levels - 1, 0, -1):
-            laterals[i - 1] += F.interpolate(
-                laterals[i], scale_factor=2, mode="bilinear"
+            laterals.insert(
+                0,
+                laterals_[i - 1] + F.interpolate(
+                    laterals_[i], scale_factor=2, mode="bilinear"
+                )
             )
 
         # build outputs


### PR DESCRIPTION
Thank you for great OSS!

When we use FPN, we get the following error on torch==1.13.1.
It looks like this is due to an in-place update of `laterals` at `FPN.forward()` in fpn.py.

```text
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [1, 64, 20, 20]], which is output 0 of LeakyReluBackward1, is at version 2; expected version 1 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True).
```

Here is the difference of yaml file.

```bash
$ git diff config/nanodet-plus-m_320.yml
     fpn:
-      name: GhostPAN
+      name: FPN # GhostPAN
       in_channels: [116, 232, 464]
-      out_channels: 96
-      kernel_size: 5
-      num_extra_level: 1
-      use_depthwise: True
+      num_outs: 3
+      out_channels: 96
       activation: LeakyReLU
     head:
-      strides: [8, 16, 32, 64]
+      strides: [8, 16, 32]
     aux_head:
-      strides: [8, 16, 32, 64]
+      strides: [8, 16, 32]
```

