### PR TITLE
Update nanodet.cpp

### DIFF
--- a/demo_ncnn/nanodet.cpp
+++ b/demo_ncnn/nanodet.cpp
@@ -160,9 +160,9 @@ void NanoDet::decode_infer(ncnn::Mat& feats, std::vector<CenterPrior>& center_pr
         int cur_label = 0;
         for (int label = 0; label < this->num_class; label++)
         {
-            if (scores[label] > score)
+            if (sigmoid(scores[label]) > score)
             {
-                score = scores[label];
+                score = sigmoid(scores[label]);
                 cur_label = label;
             }
         }


### PR DESCRIPTION
To ensure confidence values are in the correct range and will fill the difference in confidence value changes in python and cpp output.

Eg. This solved my issue where the nanodet python code was giving 95% confidence on a detection whereas the cpp code was giving >200% confidence on the same detection

