### PR TITLE
Guard CUDA calls with an explicit check

### DIFF
--- a/nanodet/model/arch/one_stage_detector.py
+++ b/nanodet/model/arch/one_stage_detector.py
@@ -47,14 +47,23 @@ class OneStageDetector(nn.Module):
 
     def inference(self, meta):
         with torch.no_grad():
-            torch.cuda.synchronize()
+            is_cuda_available = torch.cuda.is_available()
+            if is_cuda_available:
+                torch.cuda.synchronize()
+
             time1 = time.time()
             preds = self(meta["img"])
-            torch.cuda.synchronize()
+
+            if is_cuda_available:
+                torch.cuda.synchronize()
+
             time2 = time.time()
             print("forward time: {:.3f}s".format((time2 - time1)), end=" | ")
             results = self.head.post_process(preds, meta)
-            torch.cuda.synchronize()
+            
+            if is_cuda_available:
+                torch.cuda.synchronize()
+
             print("decode time: {:.3f}s".format((time.time() - time2)), end=" | ")
         return results
 


### PR DESCRIPTION
If called on `MacOS` where `CUDA` is not available the method will crash with the following error:


```
  File "/nanodet/model/arch/one_stage_detector.py", line 50, in inference
    torch.cuda.synchronize()
  File "/python3.9/site-packages/torch/cuda/__init__.py", line 564, in synchronize
    _lazy_init()
  File "/python3.9/site-packages/torch/cuda/__init__.py", line 221, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
```

The proposed fix is to check if `CUDA` is available before accessing the API