### PR TITLE
fix yolo datasets image_file path

### DIFF
--- a/nanodet/data/dataset/yolo.py
+++ b/nanodet/data/dataset/yolo.py
@@ -83,7 +83,8 @@ class YoloDataset(CocoDataset):
 
         for idx, txt_name in enumerate(ann_file_names):
             ann_file = os.path.join(ann_path, txt_name)
-            image_file = self._find_image(os.path.splitext(ann_file)[0])
+            image_file = self._find_image(os.path.join(
+                self.img_path, os.path.splitext(txt_name)[0]))
 
             if image_file is None:
                 logging.warning(f"Could not find image for {ann_file}")


### PR DESCRIPTION
原有image_file处理只是单纯的在标签文件夹内寻找图片，无视了img_path的设置，当标签与图片不在同一文件夹下则会报错。