### PR TITLE
Added pre-trained weights for ShuffleNetV2 x1.5 and x2.0

### DIFF
--- a/nanodet/model/backbone/shufflenetv2.py
+++ b/nanodet/model/backbone/shufflenetv2.py
@@ -8,7 +8,7 @@ model_urls = {
     "shufflenetv2_0.5x": "https://download.pytorch.org/models/shufflenetv2_x0.5-f707e7126e.pth",  # noqa: E501
     "shufflenetv2_1.0x": "https://download.pytorch.org/models/shufflenetv2_x1-5666bf0f80.pth",  # noqa: E501
     "shufflenetv2_1.5x": "https://download.pytorch.org/models/shufflenetv2_x1_5-3c479a10.pth",  # noqa: E501
-    "shufflenetv2_2.0x": "https://download.pytorch.org/models/shufflenetv2_x2_0-8be3c8ee.pth",
+    "shufflenetv2_2.0x": "https://download.pytorch.org/models/shufflenetv2_x2_0-8be3c8ee.pth",  # noqa: E501
 }
 
 

--- a/nanodet/model/backbone/shufflenetv2.py
+++ b/nanodet/model/backbone/shufflenetv2.py
@@ -7,7 +7,7 @@ from ..module.activation import act_layers
 model_urls = {
     "shufflenetv2_0.5x": "https://download.pytorch.org/models/shufflenetv2_x0.5-f707e7126e.pth",  # noqa: E501
     "shufflenetv2_1.0x": "https://download.pytorch.org/models/shufflenetv2_x1-5666bf0f80.pth",  # noqa: E501
-    "shufflenetv2_1.5x": "https://download.pytorch.org/models/shufflenetv2_x1_5-3c479a10.pth",
+    "shufflenetv2_1.5x": "https://download.pytorch.org/models/shufflenetv2_x1_5-3c479a10.pth",  # noqa: E501
     "shufflenetv2_2.0x": "https://download.pytorch.org/models/shufflenetv2_x2_0-8be3c8ee.pth",
 }
 

--- a/nanodet/model/backbone/shufflenetv2.py
+++ b/nanodet/model/backbone/shufflenetv2.py
@@ -7,8 +7,8 @@ from ..module.activation import act_layers
 model_urls = {
     "shufflenetv2_0.5x": "https://download.pytorch.org/models/shufflenetv2_x0.5-f707e7126e.pth",  # noqa: E501
     "shufflenetv2_1.0x": "https://download.pytorch.org/models/shufflenetv2_x1-5666bf0f80.pth",  # noqa: E501
-    "shufflenetv2_1.5x": None,
-    "shufflenetv2_2.0x": None,
+    "shufflenetv2_1.5x": "https://download.pytorch.org/models/shufflenetv2_x1_5-3c479a10.pth",
+    "shufflenetv2_2.0x": "https://download.pytorch.org/models/shufflenetv2_x2_0-8be3c8ee.pth",
 }
 
 


### PR DESCRIPTION
[Pre-trained shufflenetv2 (x1.5 and x2.0) not being supported](https://github.com/pytorch/vision/issues/3257) links to [an issue about adding more pre-trained weights](https://github.com/pytorch/vision/issues/2707), which has a link to [a merged PR adding them to the repo](https://github.com/pytorch/vision/pull/5906), which in turn links the missing weights.

Closes #524