### PR TITLE
Replaced opencv with imagesize to get the actual image size

### DIFF
--- a/nanodet/data/dataset/yolo.py
+++ b/nanodet/data/dataset/yolo.py
@@ -18,8 +18,8 @@ import time
 from collections import defaultdict
 from typing import Optional, Sequence
 
-import cv2
 import numpy as np
+from imagesize import imagesize
 from pycocotools.coco import COCO
 
 from .coco import CocoDataset
@@ -53,8 +53,8 @@ class YoloDataset(CocoDataset):
 
     @staticmethod
     def _find_image(
-        image_prefix: str,
-        image_types: Sequence[str] = (".png", ".jpg", ".jpeg", ".bmp", ".tiff"),
+            image_prefix: str,
+            image_types: Sequence[str] = (".png", ".jpg", ".jpeg", ".bmp", ".tiff"),
     ) -> Optional[str]:
         for image_type in image_types:
             path = f"{image_prefix}{image_type}"
@@ -92,8 +92,7 @@ class YoloDataset(CocoDataset):
             with open(ann_file, "r") as f:
                 lines = f.readlines()
 
-            image = cv2.imread(image_file)
-            height, width = image.shape[:2]
+            width, height = imagesize.get(image_file)
 
             file_name = os.path.basename(image_file)
             info = {

--- a/nanodet/data/dataset/yolo.py
+++ b/nanodet/data/dataset/yolo.py
@@ -53,8 +53,8 @@ class YoloDataset(CocoDataset):
 
     @staticmethod
     def _find_image(
-            image_prefix: str,
-            image_types: Sequence[str] = (".png", ".jpg", ".jpeg", ".bmp", ".tiff"),
+        image_prefix: str,
+        image_types: Sequence[str] = (".png", ".jpg", ".jpeg", ".bmp", ".tiff"),
     ) -> Optional[str]:
         for image_type in image_types:
             path = f"{image_prefix}{image_type}"

--- a/nanodet/model/arch/one_stage_detector.py
+++ b/nanodet/model/arch/one_stage_detector.py
@@ -60,7 +60,7 @@ class OneStageDetector(nn.Module):
             time2 = time.time()
             print("forward time: {:.3f}s".format((time2 - time1)), end=" | ")
             results = self.head.post_process(preds, meta)
-            
+
             if is_cuda_available:
                 torch.cuda.synchronize()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Cython
+imagesize
 matplotlib
 numpy
 omegaconf>=2.0.1


### PR DESCRIPTION
As described in https://github.com/RangiLyu/nanodet/issues/530, this PR replaces the use of opencv with the imagesize package to increase performance.