### PR TITLE
Update nanodet_plus_head.py

### DIFF
--- a/nanodet/model/head/nanodet_plus_head.py
+++ b/nanodet/model/head/nanodet_plus_head.py
@@ -266,10 +266,9 @@ class NanoDetPlusHead(nn.Module):
             (labels >= 0) & (labels < self.num_classes), as_tuple=False
         ).squeeze(1)
 
+        weight_targets = cls_preds[pos_inds].detach().sigmoid().max(dim=1)[0]
+        bbox_avg_factor = max(reduce_mean(weight_targets.sum()).item(), 1.0)
         if len(pos_inds) > 0:
-            weight_targets = cls_preds[pos_inds].detach().sigmoid().max(dim=1)[0]
-            bbox_avg_factor = max(reduce_mean(weight_targets.sum()).item(), 1.0)
-
             loss_bbox = self.loss_bbox(
                 decoded_bboxes[pos_inds],
                 bbox_targets[pos_inds],


### PR DESCRIPTION
修复多GPU情况下，len(pos_inds) == 0时（当前Batch中的所有图像中均没有检测框真值），reduce_mean不执行导致的dist.all_reduce空等待，卡死的问题。