### PR TITLE
Bug fix on celling operation in nanodet plus head.

### DIFF
--- a/nanodet/model/head/nanodet_plus_head.py
+++ b/nanodet/model/head/nanodet_plus_head.py
@@ -477,7 +477,7 @@ class NanoDetPlusHead(nn.Module):
         input_shape = (input_height, input_width)
 
         featmap_sizes = [
-            (math.ceil(input_height / stride), math.ceil(input_width) / stride)
+            (math.ceil(input_height / stride), math.ceil(input_width / stride))
             for stride in self.strides
         ]
         # get grid cells of one image


### PR DESCRIPTION
Resolved an issue where the feature map size remained a float due to incorrect application of the ceil operation. Now ensures the output size is properly cast to an integer.